### PR TITLE
Fix: fix isort error

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2,6 +2,7 @@ import os
 import shlex
 
 import pytest
+
 from click._bashcomplete import get_choices
 
 from afs import __version__


### PR DESCRIPTION
Notice the CI build has an error due to `isort`. This PR just fix it.